### PR TITLE
ライセンス関連ファイルの追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,8 @@ jobs:
 
       - name: Add licence.txt
         run: |
-          - cargo install cargo-license
-          - cargo license > target/release/licence.txt
+          cargo install cargo-license
+          cargo license > target/release/licence.txt
 
       - name: Archive to zip
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,15 @@ jobs:
       - name: Build
         run: cargo build --release --verbose
 
+      - name: Add licence.txt
+        run: |
+          - cargo install cargo-license
+          - cargo license > target/release/licence.txt
+
       - name: Archive to zip
         run: |
           New-Item -ItemType Directory dist
-          Compress-Archive -Path target/release/send-vrc-desktop.exe -DestinationPath dist/send-vrc-desktop-${{ needs.get-release-version.outputs.release_version }}-x86_64-pc-windows-msvc.zip
+          Compress-Archive -Path target/release/send-vrc-desktop.exe,target/release/licence.txt -DestinationPath dist/send-vrc-desktop-${{ needs.get-release-version.outputs.release_version }}-x86_64-pc-windows-msvc.zip
 
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "send-vrc-desktop"
 version = "1.0.1"
 edition = "2021"
+license = "MIT"
 
 [dependencies]
 anyhow = "1.0.58"


### PR DESCRIPTION
- 配布物にライセンスファイルを同梱するために GitHub Actions の修正をした．
- `Cargo.toml` にライセンスの記載がなかったため追加